### PR TITLE
Navigation Cube sync suggestion

### DIFF
--- a/component_editor/index.html
+++ b/component_editor/index.html
@@ -41,7 +41,8 @@
     <script type='text/javascript' src="../static/js/ReferenceSystem.js"></script>
     <script type='text/javascript' src="../static/js/UI.js"></script>
     <script type='text/javascript' src="../static/js/Controller.js"></script>
-    <script type='text/javascript' src="../static/js/jquery.viewConnector.js"></script>
+    <!-- <script type='text/javascript' src="../static/js/jquery.viewConnector.js"></script> -->
+    <script type='text/javascript' src="../static/js/jquery.viewConnector2.js"></script>
     <script type='text/javascript' src="../static/js/EditorBase.js"></script>
     <script type='text/javascript' src="../static/js/EventSystem.js"></script>
     <script type='text/javascript' src="../static/js/GizmoController.js"></script>
@@ -426,7 +427,7 @@
         <div id="viewpointControl">
             <x3d id="x3domOrientationSceneView">
                 <scene>
-                    <navigationInfo type='"NONE" "ANY"'></navigationInfo>
+                    <navigationInfo type='"TURNTABLE"'></navigationInfo>
                     <viewpoint position="0.0 0.0 2.95"></viewpoint>
                     <transform id="orientationBox">
                         <inline url="../static/x3d/orientationBox.x3d" mapDEFToID="true" namespaceName="orientationBox"></inline>

--- a/static/js/jquery.viewConnector2.js
+++ b/static/js/jquery.viewConnector2.js
@@ -1,0 +1,133 @@
+$.fn.viewConnector = (function () {
+
+    var SFMatrix4f = x3dom.fields.SFMatrix4f;
+    var SFVec3f = x3dom.fields.SFVec3f;
+
+    return function (options, command) {
+
+
+        var that = this,
+            api = {
+                connected : null,
+                viewport : 'both', // 'dest', 'origin'
+                active:null,
+                resetActive: function() {
+                    api.active = null;
+                    clearTimeout(api._reset)
+                },
+                bind : function() {
+                    var $dest = $( typeof api.connected == 'string' ? '#' + api.connected : api.connected),
+                        $origin = $(that);
+
+                    if(api.viewport != 'origin') {
+                        try {
+                            $dest.find('viewpoint,orthoviewpoint').on('viewpointChanged', function(event) {
+
+                                if($dest != api.active && api.active != null) return;
+                                api.active = $dest;
+                                clearTimeout(api._reset)
+                                api._reset = setTimeout(api.resetActive, 60)
+
+                                var e = event.originalEvent;
+                                api.setOrientation($origin[0].runtime, $dest[0].runtime, e)
+                            })
+                        } catch(e) {
+                            console.error(e)
+                        }
+                        
+                    }
+
+                    if(api.viewport != 'dest') {
+                        try {
+                            $origin.find('viewpoint,orthoviewpoint').on('viewpointChanged', function(event) {
+                                if($origin != api.active && api.active != null) return;
+                                api.active = $origin;
+                                clearTimeout(api._reset)
+                                api._reset = setTimeout(api.resetActive, 60)
+
+                                var e = event.originalEvent;
+                                api.setOrientation($dest[0].runtime, $origin[0].runtime, e)
+                            })
+                        } catch(e) {
+                            console.error(e)   
+                        }
+                    }
+
+                    return that;
+                },
+                setOrientation : function(runtime, target, event) {
+                    
+
+
+                    var viewpoint = runtime.viewpoint(),
+                        _xmlNode = viewpoint._xmlNode,
+                        position,
+                        orientation;
+
+                    
+                    if( target.canvas.doc._viewarea.isAnimating() ) return;
+                    
+
+                    if(!_xmlNode) {
+                        
+                        throw "No <viewpoint> set";
+                    }
+
+                    try {
+                        _xmlNode = $(_xmlNode);
+
+                        var position = SFVec3f.parse( _xmlNode.attr('position') || "0,0,0" )
+                        var vpLength = SFVec3f.parse( _xmlNode.attr('position') || "0,0,0" ).subtract( viewpoint.getCenterOfRotation() ).length();
+
+                        // Pos(t1) = CoR(t1) + dist( CoR(t2) - Pos(t2)  )
+                        // normalize returns the unit vector ( direction vector )
+                        position = viewpoint.getCenterOfRotation()
+                            .add( 
+                                //distance between CoR and the target viewpoint
+                                event.position
+                                .subtract( 
+                                    target.viewpoint().getCenterOfRotation()
+                                )
+                            .normalize()
+                            .multiply(vpLength) 
+                        );
+                         _xmlNode.attr('orientation', event.orientation)
+                            .attr('position', position )
+
+                    } catch(e) {
+                        console.error(e)
+                    }
+                   
+                    // Disable the mouse button pan - but it has some issues when rotating with CoR != [0,0,0]
+                    // viewpoint._viewMatrix._03 =
+                    // viewpoint._viewMatrix._13 = 0;
+                    // viewpoint._viewMatrix._23 = -vpLength;
+
+                    // runtime.triggerRedraw();
+                },
+                unbind : function() {
+                }
+            }
+
+        if(this.data('x3dsync')) {
+            api = this.data('x3dsync')
+        } else {
+            this.data('x3dsync', api)
+        }
+
+        // get the command;
+        if(typeof options == 'string' && _.include(_.keys(api), options) ) {
+            command = options;
+            return _.isFunction( api[command] ) ? api[command]() : api[command];
+        }
+
+//        _.extend(api, options);
+        for(var k in options) {
+            api[k] = options[k]
+        }
+
+        return api.bind()
+    
+    }
+
+})()

--- a/static/js/jquery.viewConnector2.js
+++ b/static/js/jquery.viewConnector2.js
@@ -9,9 +9,9 @@ $.fn.viewConnector = (function () {
         var that = this,
             api = {
                 connected : null,
-                viewport : 'both', // 'dest', 'origin'
-                active:null,
-                resetActive: function() {
+                viewport  : 'both', // 'dest', 'origin'
+                active    : null,
+                resetActive : function() {
                     api.active = null;
                     clearTimeout(api._reset)
                 },
@@ -56,20 +56,14 @@ $.fn.viewConnector = (function () {
                     return that;
                 },
                 setOrientation : function(runtime, target, event) {
-                    
-
-
                     var viewpoint = runtime.viewpoint(),
                         _xmlNode = viewpoint._xmlNode,
                         position,
                         orientation;
 
-                    
                     if( target.canvas.doc._viewarea.isAnimating() ) return;
                     
-
                     if(!_xmlNode) {
-                        
                         throw "No <viewpoint> set";
                     }
 

--- a/static/js/jquery.viewConnector2.js
+++ b/static/js/jquery.viewConnector2.js
@@ -109,19 +109,19 @@ $.fn.viewConnector = (function () {
                 }
             }
 
-        if(this.data('x3dsync')) {
-            api = this.data('x3dsync')
+        if(this.data('viewConnector')) {
+            api = this.data('viewConnector')
         } else {
-            this.data('x3dsync', api)
+            this.data('viewConnector', api)
         }
 
         // get the command;
-        if(typeof options == 'string' && _.include(_.keys(api), options) ) {
-            command = options;
-            return _.isFunction( api[command] ) ? api[command]() : api[command];
-        }
+        // if(typeof options == 'string' && _.include(_.keys(api), options) ) {
+        //     command = options;
+        //     return _.isFunction( api[command] ) ? api[command]() : api[command];
+        // }
 
-//        _.extend(api, options);
+        //  _.extend(api, options);
         for(var k in options) {
             api[k] = options[k]
         }


### PR DESCRIPTION
I wrote a simple jq plugin to help with synchronisation. It has a few issues when panning or changing to orthoview.

What it does it's listening to viewpointChanged event ( i tried to add handler to enterFrame, but there are no orientation and position params ) of viewpoint or orthoviewpoint, getting the orientation and the position from the event and setting the orientation and the position to the bound viewpoint. Before setting the position - multiplying the unit vector of the position to the current distance to the center of rotation.

Probably not the best naming of the variables - the setOrientation target param refers to the event.target. This could be misleading.  
